### PR TITLE
feat: add AbortSignal support to all resource methods #4

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,3 +101,11 @@
 | `createStatus(data)` | `POST /repos/{owner}/{repo}/statuses/{sha}` | ⬜ |
 | `comments(params?)` | `GET /repos/{owner}/{repo}/commits/{commit_sha}/comments` | ⬜ |
 | `addComment(data)` | `POST /repos/{owner}/{repo}/commits/{commit_sha}/comments` | ⬜ |
+
+---
+
+## Cross-cutting concerns
+
+| Feature | Scope | Status |
+|---------|-------|--------|
+| `AbortSignal` support | All resource methods (pass `signal` to `fetch`) | ✅ |

--- a/src/GitHubClient.ts
+++ b/src/GitHubClient.ts
@@ -121,7 +121,7 @@ export class GitHubClient {
   private async request<T>(
     path: string,
     params?: Record<string, string | number | boolean>,
-    options?: { headers?: Record<string, string> },
+    options?: { headers?: Record<string, string>; signal?: AbortSignal },
   ): Promise<T> {
     const base = `${this.security.getApiUrl()}${path}`;
     const url = buildUrl(base, params);
@@ -129,7 +129,7 @@ export class GitHubClient {
     let statusCode: number | undefined;
     try {
       const headers = options?.headers ?? this.security.getHeaders();
-      const response = await fetch(url, { headers });
+      const response = await fetch(url, { headers, signal: options?.signal });
       statusCode = response.status;
       if (!response.ok) {
         throw new GitHubApiError(response.status, response.statusText);
@@ -152,13 +152,14 @@ export class GitHubClient {
   private async requestList<T>(
     path: string,
     params?: Record<string, string | number | boolean>,
+    signal?: AbortSignal,
   ): Promise<GitHubPagedResponse<T>> {
     const base = `${this.security.getApiUrl()}${path}`;
     const url = buildUrl(base, params);
     const startedAt = new Date();
     let statusCode: number | undefined;
     try {
-      const response = await fetch(url, { headers: this.security.getHeaders() });
+      const response = await fetch(url, { headers: this.security.getHeaders(), signal });
       statusCode = response.status;
       if (!response.ok) {
         throw new GitHubApiError(response.status, response.statusText);
@@ -187,13 +188,14 @@ export class GitHubClient {
   private async requestText(
     path: string,
     params?: Record<string, string | number | boolean>,
+    signal?: AbortSignal,
   ): Promise<string> {
     const base = `${this.security.getApiUrl()}${path}`;
     const url = buildUrl(base, params);
     const startedAt = new Date();
     let statusCode: number | undefined;
     try {
-      const response = await fetch(url, { headers: this.security.getRawHeaders() });
+      const response = await fetch(url, { headers: this.security.getRawHeaders(), signal });
       statusCode = response.status;
       if (!response.ok) {
         throw new GitHubApiError(response.status, response.statusText);
@@ -209,21 +211,21 @@ export class GitHubClient {
   }
 
   private makeRequestFn(): RequestFn {
-    return <T>(path: string, params?: Record<string, string | number | boolean>) =>
-      this.request<T>(path, params);
+    return <T>(path: string, params?: Record<string, string | number | boolean>, signal?: AbortSignal) =>
+      this.request<T>(path, params, { signal });
   }
 
   private makeRequestListFn(): RequestListFn {
-    return <T>(path: string, params?: Record<string, string | number | boolean>) =>
-      this.requestList<T>(path, params);
+    return <T>(path: string, params?: Record<string, string | number | boolean>, signal?: AbortSignal) =>
+      this.requestList<T>(path, params, signal);
   }
 
   private makeRequestTextFn(): RequestTextFn {
-    return (path: string, params?: Record<string, string | number | boolean>) =>
-      this.requestText(path, params);
+    return (path: string, params?: Record<string, string | number | boolean>, signal?: AbortSignal) =>
+      this.requestText(path, params, signal);
   }
 
-  private async requestPost<T>(path: string, body: unknown): Promise<T> {
+  private async requestPost<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
     const url = `${this.security.getApiUrl()}${path}`;
     const startedAt = new Date();
     let statusCode: number | undefined;
@@ -232,6 +234,7 @@ export class GitHubClient {
         method: 'POST',
         headers: this.security.getHeaders(),
         body: JSON.stringify(body),
+        signal,
       });
       statusCode = response.status;
       if (!response.ok) {
@@ -248,11 +251,11 @@ export class GitHubClient {
   }
 
   private makeRequestBodyFn(): RequestBodyFn {
-    return <T>(path: string, body: unknown) =>
-      this.requestPost<T>(path, body);
+    return <T>(path: string, body: unknown, signal?: AbortSignal) =>
+      this.requestPost<T>(path, body, signal);
   }
 
-  private async requestPatch<T>(path: string, body: unknown): Promise<T> {
+  private async requestPatch<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
     const url = `${this.security.getApiUrl()}${path}`;
     const startedAt = new Date();
     let statusCode: number | undefined;
@@ -261,6 +264,7 @@ export class GitHubClient {
         method: 'PATCH',
         headers: this.security.getHeaders(),
         body: JSON.stringify(body),
+        signal,
       });
       statusCode = response.status;
       if (!response.ok) {
@@ -276,7 +280,7 @@ export class GitHubClient {
     }
   }
 
-  private async requestDelete(path: string): Promise<void> {
+  private async requestDelete(path: string, signal?: AbortSignal): Promise<void> {
     const url = `${this.security.getApiUrl()}${path}`;
     const startedAt = new Date();
     let statusCode: number | undefined;
@@ -284,6 +288,7 @@ export class GitHubClient {
       const response = await fetch(url, {
         method: 'DELETE',
         headers: this.security.getHeaders(),
+        signal,
       });
       statusCode = response.status;
       if (!response.ok) {
@@ -298,13 +303,13 @@ export class GitHubClient {
   }
 
   private makeRequestPatchFn(): RequestPatchFn {
-    return <T>(path: string, body: unknown) =>
-      this.requestPatch<T>(path, body);
+    return <T>(path: string, body: unknown, signal?: AbortSignal) =>
+      this.requestPatch<T>(path, body, signal);
   }
 
   private makeRequestDeleteFn(): RequestDeleteFn {
-    return (path: string) =>
-      this.requestDelete(path);
+    return (path: string, signal?: AbortSignal) =>
+      this.requestDelete(path, signal);
   }
 
   /**
@@ -320,8 +325,8 @@ export class GitHubClient {
    * console.log(me.login); // 'octocat'
    * ```
    */
-  async currentUser(): Promise<GitHubUser> {
-    return this.request<GitHubUser>('/user');
+  async currentUser(signal?: AbortSignal): Promise<GitHubUser> {
+    return this.request<GitHubUser>('/user', undefined, { signal });
   }
 
   /**
@@ -424,13 +429,13 @@ export class GitHubClient {
    * console.log(`Found ${results.totalCount} repositories`);
    * ```
    */
-  async searchRepos(params: SearchReposParams): Promise<GitHubPagedResponse<GitHubRepository>> {
+  async searchRepos(params: SearchReposParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubRepository>> {
     const base = `${this.security.getApiUrl()}/search/repositories`;
     const url = buildUrl(base, params as unknown as Record<string, string | number | boolean>);
     const startedAt = new Date();
     let statusCode: number | undefined;
     try {
-      const response = await fetch(url, { headers: this.security.getHeaders() });
+      const response = await fetch(url, { headers: this.security.getHeaders(), signal });
       statusCode = response.status;
       if (!response.ok) {
         throw new GitHubApiError(response.status, response.statusText);

--- a/src/resources/CommitResource.ts
+++ b/src/resources/CommitResource.ts
@@ -58,8 +58,8 @@ export class CommitResource implements PromiseLike<GitHubCommit> {
    *
    * @returns The commit object with stats and files
    */
-  async get(): Promise<GitHubCommit> {
-    return this.request<GitHubCommit>(this.basePath);
+  async get(signal?: AbortSignal): Promise<GitHubCommit> {
+    return this.request<GitHubCommit>(this.basePath, undefined, signal);
   }
 
   /**
@@ -70,11 +70,12 @@ export class CommitResource implements PromiseLike<GitHubCommit> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of commit statuses
    */
-  async statuses(params?: CommitStatusesParams): Promise<GitHubPagedResponse<GitHubCommitStatus>> {
+  async statuses(params?: CommitStatusesParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubCommitStatus>> {
     const repoPath = this.basePath.replace(`/commits/${this.ref}`, '');
     return this.requestList<GitHubCommitStatus>(
       `${repoPath}/statuses/${this.ref}`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -85,8 +86,8 @@ export class CommitResource implements PromiseLike<GitHubCommit> {
    *
    * @returns The combined status object
    */
-  async combinedStatus(): Promise<GitHubCombinedStatus> {
-    return this.request<GitHubCombinedStatus>(`${this.basePath}/status`);
+  async combinedStatus(signal?: AbortSignal): Promise<GitHubCombinedStatus> {
+    return this.request<GitHubCombinedStatus>(`${this.basePath}/status`, undefined, signal);
   }
 
   /**
@@ -97,10 +98,11 @@ export class CommitResource implements PromiseLike<GitHubCommit> {
    * @param params - Optional filters: `check_name`, `status`, `app_id`, `per_page`, `page`
    * @returns A paged response of check runs
    */
-  async checkRuns(params?: CheckRunsParams): Promise<GitHubPagedResponse<GitHubCheckRun>> {
+  async checkRuns(params?: CheckRunsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubCheckRun>> {
     const raw = await this.request<{ check_runs: GitHubCheckRun[] }>(
       `${this.basePath}/check-runs`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
     return {
       values: raw.check_runs,

--- a/src/resources/IssueResource.ts
+++ b/src/resources/IssueResource.ts
@@ -49,8 +49,8 @@ export class IssueResource implements PromiseLike<GitHubIssue> {
    *
    * @returns The issue object
    */
-  async get(): Promise<GitHubIssue> {
-    return this.request<GitHubIssue>(this.basePath);
+  async get(signal?: AbortSignal): Promise<GitHubIssue> {
+    return this.request<GitHubIssue>(this.basePath, undefined, signal);
   }
 
   /**
@@ -61,10 +61,11 @@ export class IssueResource implements PromiseLike<GitHubIssue> {
    * @param params - Optional filters: `since`, `per_page`, `page`
    * @returns A paged response of comments
    */
-  async comments(params?: PaginationParams & { since?: string }): Promise<GitHubPagedResponse<GitHubIssueComment>> {
+  async comments(params?: PaginationParams & { since?: string }, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubIssueComment>> {
     return this.requestList<GitHubIssueComment>(
       `${this.basePath}/comments`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 }

--- a/src/resources/OrganizationResource.ts
+++ b/src/resources/OrganizationResource.ts
@@ -8,34 +8,39 @@ import { RepositoryResource } from './RepositoryResource';
 export type RequestFn = <T>(
   path: string,
   params?: Record<string, string | number | boolean>,
+  signal?: AbortSignal,
 ) => Promise<T>;
 
 /** @internal */
 export type RequestListFn = <T>(
   path: string,
   params?: Record<string, string | number | boolean>,
+  signal?: AbortSignal,
 ) => Promise<GitHubPagedResponse<T>>;
 
 /** @internal */
 export type RequestTextFn = (
   path: string,
   params?: Record<string, string | number | boolean>,
+  signal?: AbortSignal,
 ) => Promise<string>;
 
 /** @internal */
 export type RequestBodyFn = <T>(
   path: string,
   body: unknown,
+  signal?: AbortSignal,
 ) => Promise<T>;
 
 /** @internal */
 export type RequestPatchFn = <T>(
   path: string,
   body: unknown,
+  signal?: AbortSignal,
 ) => Promise<T>;
 
 /** @internal */
-export type RequestDeleteFn = (path: string) => Promise<void>;
+export type RequestDeleteFn = (path: string, signal?: AbortSignal) => Promise<void>;
 
 /**
  * Represents a GitHub organization resource with chainable async methods.
@@ -88,8 +93,8 @@ export class OrganizationResource implements PromiseLike<GitHubOrganization> {
    *
    * @returns The organization object
    */
-  async get(): Promise<GitHubOrganization> {
-    return this.request<GitHubOrganization>(`/orgs/${this.org}`);
+  async get(signal?: AbortSignal): Promise<GitHubOrganization> {
+    return this.request<GitHubOrganization>(`/orgs/${this.org}`, undefined, signal);
   }
 
   /**
@@ -100,10 +105,11 @@ export class OrganizationResource implements PromiseLike<GitHubOrganization> {
    * @param params - Optional filters: `type`, `sort`, `direction`, `per_page`, `page`
    * @returns A paged response of repositories
    */
-  async repos(params?: ReposParams): Promise<GitHubPagedResponse<GitHubRepository>> {
+  async repos(params?: ReposParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubRepository>> {
     return this.requestList<GitHubRepository>(
       `/orgs/${this.org}/repos`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -144,10 +150,11 @@ export class OrganizationResource implements PromiseLike<GitHubOrganization> {
    * @param params - Optional filters: `role`, `filter`, `per_page`, `page`
    * @returns A paged response of users
    */
-  async members(params?: OrgMembersParams): Promise<GitHubPagedResponse<GitHubUser>> {
+  async members(params?: OrgMembersParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubUser>> {
     return this.requestList<GitHubUser>(
       `/orgs/${this.org}/members`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -169,7 +176,7 @@ export class OrganizationResource implements PromiseLike<GitHubOrganization> {
    * });
    * ```
    */
-  async createRepo(data: CreateOrgRepoData): Promise<GitHubRepository> {
-    return this.requestBody<GitHubRepository>(`/orgs/${this.org}/repos`, data);
+  async createRepo(data: CreateOrgRepoData, signal?: AbortSignal): Promise<GitHubRepository> {
+    return this.requestBody<GitHubRepository>(`/orgs/${this.org}/repos`, data, signal);
   }
 }

--- a/src/resources/PullRequestResource.ts
+++ b/src/resources/PullRequestResource.ts
@@ -61,8 +61,8 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    *
    * @returns The pull request object
    */
-  async get(): Promise<GitHubPullRequest> {
-    return this.request<GitHubPullRequest>(this.basePath);
+  async get(signal?: AbortSignal): Promise<GitHubPullRequest> {
+    return this.request<GitHubPullRequest>(this.basePath, undefined, signal);
   }
 
   /**
@@ -73,10 +73,11 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of commits
    */
-  async commits(params?: PaginationParams): Promise<GitHubPagedResponse<GitHubCommit>> {
+  async commits(params?: PaginationParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubCommit>> {
     return this.requestList<GitHubCommit>(
       `${this.basePath}/commits`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -88,10 +89,11 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of changed files
    */
-  async files(params?: PullRequestFilesParams): Promise<GitHubPagedResponse<GitHubPullRequestFile>> {
+  async files(params?: PullRequestFilesParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubPullRequestFile>> {
     return this.requestList<GitHubPullRequestFile>(
       `${this.basePath}/files`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -103,10 +105,11 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of reviews
    */
-  async reviews(params?: ReviewsParams): Promise<GitHubPagedResponse<GitHubReview>> {
+  async reviews(params?: ReviewsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubReview>> {
     return this.requestList<GitHubReview>(
       `${this.basePath}/reviews`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -118,10 +121,11 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    * @param params - Optional filters: `sort`, `direction`, `since`, `per_page`, `page`
    * @returns A paged response of review comments
    */
-  async reviewComments(params?: ReviewCommentsParams): Promise<GitHubPagedResponse<GitHubReviewComment>> {
+  async reviewComments(params?: ReviewCommentsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubReviewComment>> {
     return this.requestList<GitHubReviewComment>(
       `${this.basePath}/comments`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -132,11 +136,12 @@ export class PullRequestResource implements PromiseLike<GitHubPullRequest> {
    *
    * @returns `true` if merged (HTTP 204), `false` if not merged (HTTP 404)
    */
-  async isMerged(): Promise<boolean> {
+  async isMerged(signal?: AbortSignal): Promise<boolean> {
     try {
-      await this.request<never>(`${this.basePath}/merge`);
+      await this.request<never>(`${this.basePath}/merge`, undefined, signal);
       return true;
-    } catch {
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') throw err;
       return false;
     }
   }

--- a/src/resources/RepositoryResource.ts
+++ b/src/resources/RepositoryResource.ts
@@ -76,8 +76,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    *
    * @returns The repository object
    */
-  async get(): Promise<GitHubRepository> {
-    return this.request<GitHubRepository>(this.basePath);
+  async get(signal?: AbortSignal): Promise<GitHubRepository> {
+    return this.request<GitHubRepository>(this.basePath, undefined, signal);
   }
 
   /**
@@ -88,10 +88,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional filters: `state`, `head`, `base`, `sort`, `direction`, `per_page`, `page`
    * @returns A paged response of pull requests
    */
-  async pullRequests(params?: PullRequestsParams): Promise<GitHubPagedResponse<GitHubPullRequest>> {
+  async pullRequests(params?: PullRequestsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubPullRequest>> {
     return this.requestList<GitHubPullRequest>(
       `${this.basePath}/pulls`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -119,10 +120,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional filters: `sha`, `path`, `author`, `since`, `until`, `per_page`, `page`
    * @returns A paged response of commits
    */
-  async commits(params?: CommitsParams): Promise<GitHubPagedResponse<GitHubCommit>> {
+  async commits(params?: CommitsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubCommit>> {
     return this.requestList<GitHubCommit>(
       `${this.basePath}/commits`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -150,10 +152,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional filters: `protected`, `per_page`, `page`
    * @returns A paged response of branches
    */
-  async branches(params?: BranchesParams): Promise<GitHubPagedResponse<GitHubBranch>> {
+  async branches(params?: BranchesParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubBranch>> {
     return this.requestList<GitHubBranch>(
       `${this.basePath}/branches`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -165,8 +168,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param name - The branch name (e.g., `'main'`)
    * @returns The branch object
    */
-  async branch(name: string): Promise<GitHubBranch> {
-    return this.request<GitHubBranch>(`${this.basePath}/branches/${encodeURIComponent(name)}`);
+  async branch(name: string, signal?: AbortSignal): Promise<GitHubBranch> {
+    return this.request<GitHubBranch>(`${this.basePath}/branches/${encodeURIComponent(name)}`, undefined, signal);
   }
 
   /**
@@ -177,10 +180,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of tags
    */
-  async tags(params?: TagsParams): Promise<GitHubPagedResponse<GitHubTag>> {
+  async tags(params?: TagsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubTag>> {
     return this.requestList<GitHubTag>(
       `${this.basePath}/tags`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -192,10 +196,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of releases
    */
-  async releases(params?: ReleasesParams): Promise<GitHubPagedResponse<GitHubRelease>> {
+  async releases(params?: ReleasesParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubRelease>> {
     return this.requestList<GitHubRelease>(
       `${this.basePath}/releases`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -206,8 +211,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    *
    * @returns The latest release object
    */
-  async latestRelease(): Promise<GitHubRelease> {
-    return this.request<GitHubRelease>(`${this.basePath}/releases/latest`);
+  async latestRelease(signal?: AbortSignal): Promise<GitHubRelease> {
+    return this.request<GitHubRelease>(`${this.basePath}/releases/latest`, undefined, signal);
   }
 
   /**
@@ -218,10 +223,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional filters: `sort`, `per_page`, `page`
    * @returns A paged response of forked repositories
    */
-  async forks(params?: ForksParams): Promise<GitHubPagedResponse<GitHubRepository>> {
+  async forks(params?: ForksParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubRepository>> {
     return this.requestList<GitHubRepository>(
       `${this.basePath}/forks`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -248,8 +254,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * });
    * ```
    */
-  async createFork(data?: CreateForkData): Promise<GitHubRepository> {
-    return this.requestBody<GitHubRepository>(`${this.basePath}/forks`, data ?? {});
+  async createFork(data?: CreateForkData, signal?: AbortSignal): Promise<GitHubRepository> {
+    return this.requestBody<GitHubRepository>(`${this.basePath}/forks`, data ?? {}, signal);
   }
 
   /**
@@ -260,10 +266,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional pagination: `per_page`, `page`
    * @returns A paged response of webhooks
    */
-  async webhooks(params?: WebhooksParams): Promise<GitHubPagedResponse<GitHubWebhook>> {
+  async webhooks(params?: WebhooksParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubWebhook>> {
     return this.requestList<GitHubWebhook>(
       `${this.basePath}/hooks`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -283,8 +290,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * });
    * ```
    */
-  async createWebhook(data: CreateWebhookData): Promise<GitHubWebhook> {
-    return this.requestBody<GitHubWebhook>(`${this.basePath}/hooks`, { name: 'web', ...data });
+  async createWebhook(data: CreateWebhookData, signal?: AbortSignal): Promise<GitHubWebhook> {
+    return this.requestBody<GitHubWebhook>(`${this.basePath}/hooks`, { name: 'web', ...data }, signal);
   }
 
   /**
@@ -304,8 +311,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * });
    * ```
    */
-  async updateWebhook(hookId: number, data: UpdateWebhookData): Promise<GitHubWebhook> {
-    return this.requestPatch<GitHubWebhook>(`${this.basePath}/hooks/${hookId}`, data);
+  async updateWebhook(hookId: number, data: UpdateWebhookData, signal?: AbortSignal): Promise<GitHubWebhook> {
+    return this.requestPatch<GitHubWebhook>(`${this.basePath}/hooks/${hookId}`, data, signal);
   }
 
   /**
@@ -320,8 +327,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * await gh.repo('octocat', 'Hello-World').deleteWebhook(1);
    * ```
    */
-  async deleteWebhook(hookId: number): Promise<void> {
-    return this.requestDelete(`${this.basePath}/hooks/${hookId}`);
+  async deleteWebhook(hookId: number, signal?: AbortSignal): Promise<void> {
+    return this.requestDelete(`${this.basePath}/hooks/${hookId}`, signal);
   }
 
   /**
@@ -334,11 +341,12 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param path - Path to the file or directory. Omit for root.
    * @param params - Optional: `ref` (branch, tag, or commit SHA)
    */
-  async contents(path?: string, params?: ContentParams): Promise<GitHubContent | GitHubContent[]> {
+  async contents(path?: string, params?: ContentParams, signal?: AbortSignal): Promise<GitHubContent | GitHubContent[]> {
     const contentPath = path ? `${this.basePath}/contents/${path}` : `${this.basePath}/contents`;
     return this.request<GitHubContent | GitHubContent[]>(
       contentPath,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -353,10 +361,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional: `ref` (branch, tag, or commit SHA)
    * @returns The raw file content as a string
    */
-  async raw(filePath: string, params?: ContentParams): Promise<string> {
+  async raw(filePath: string, params?: ContentParams, signal?: AbortSignal): Promise<string> {
     return this.requestText(
       `${this.basePath}/contents/${filePath}`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -367,8 +376,8 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    *
    * @returns An array of topic strings
    */
-  async topics(): Promise<string[]> {
-    const data = await this.request<{ names: string[] }>(`${this.basePath}/topics`);
+  async topics(signal?: AbortSignal): Promise<string[]> {
+    const data = await this.request<{ names: string[] }>(`${this.basePath}/topics`, undefined, signal);
     return data.names;
   }
 
@@ -379,10 +388,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    *
    * @param params - Optional filters: `anon`, `per_page`, `page`
    */
-  async contributors(params?: PaginationParams & { anon?: boolean }): Promise<GitHubPagedResponse<{ login?: string; id?: number; contributions: number; avatar_url?: string; html_url?: string }>> {
+  async contributors(params?: PaginationParams & { anon?: boolean }, signal?: AbortSignal): Promise<GitHubPagedResponse<{ login?: string; id?: number; contributions: number; avatar_url?: string; html_url?: string }>> {
     return this.requestList(
       `${this.basePath}/contributors`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -397,10 +407,11 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * @param params - Optional filters: `state`, `labels`, `sort`, `direction`, `since`, `per_page`, `page`
    * @returns A paged response of issues
    */
-  async issues(params?: IssuesParams): Promise<GitHubPagedResponse<GitHubIssue>> {
+  async issues(params?: IssuesParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubIssue>> {
     return this.requestList<GitHubIssue>(
       `${this.basePath}/issues`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -446,7 +457,7 @@ export class RepositoryResource implements PromiseLike<GitHubRepository> {
    * });
    * ```
    */
-  async createIssue(data: CreateIssueData): Promise<GitHubIssue> {
-    return this.requestBody<GitHubIssue>(`${this.basePath}/issues`, data);
+  async createIssue(data: CreateIssueData, signal?: AbortSignal): Promise<GitHubIssue> {
+    return this.requestBody<GitHubIssue>(`${this.basePath}/issues`, data, signal);
   }
 }

--- a/src/resources/UserResource.ts
+++ b/src/resources/UserResource.ts
@@ -56,8 +56,8 @@ export class UserResource implements PromiseLike<GitHubUser> {
    *
    * @returns The user object
    */
-  async get(): Promise<GitHubUser> {
-    return this.request<GitHubUser>(this.basePath);
+  async get(signal?: AbortSignal): Promise<GitHubUser> {
+    return this.request<GitHubUser>(this.basePath, undefined, signal);
   }
 
   /**
@@ -68,10 +68,11 @@ export class UserResource implements PromiseLike<GitHubUser> {
    * @param params - Optional filters: `type`, `sort`, `direction`, `per_page`, `page`
    * @returns A paged response of repositories
    */
-  async repos(params?: ReposParams): Promise<GitHubPagedResponse<GitHubRepository>> {
+  async repos(params?: ReposParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubRepository>> {
     return this.requestList<GitHubRepository>(
       `${this.basePath}/repos`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -108,10 +109,11 @@ export class UserResource implements PromiseLike<GitHubUser> {
    *
    * @returns A paged response of users
    */
-  async following(params?: { per_page?: number; page?: number }): Promise<GitHubPagedResponse<GitHubUser>> {
+  async following(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubUser>> {
     return this.requestList<GitHubUser>(
       `${this.basePath}/following`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 
@@ -122,10 +124,11 @@ export class UserResource implements PromiseLike<GitHubUser> {
    *
    * @returns A paged response of users
    */
-  async followers(params?: { per_page?: number; page?: number }): Promise<GitHubPagedResponse<GitHubUser>> {
+  async followers(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubUser>> {
     return this.requestList<GitHubUser>(
       `${this.basePath}/followers`,
       params as Record<string, string | number | boolean>,
+      signal,
     );
   }
 }


### PR DESCRIPTION
Each HTTP method across GitHubClient, OrganizationResource, UserResource, RepositoryResource, PullRequestResource, CommitResource, and IssueResource now accepts an optional `signal?: AbortSignal` parameter forwarded directly to fetch.

isMerged() re-throws AbortError instead of swallowing it.

Closes #4

## What does this PR do?

## Related issue

Closes #4 

## Checklist

- [x] `npm test` passes
- [x] New code has tests
- [x] `src/index.ts` exports any new public types
- [ ] README updated if a new endpoint was added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
