### PR TITLE
feat: implement GistResource with full CRUD and star/comment support #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,72 @@ const merged = await gh.repo('octocat', 'Hello-World').pullRequest(42).isMerged(
 // true | false
 ```
 
+### Issues
+
+```typescript
+// List issues in a repository
+const issues = await gh.repo('octocat', 'Hello-World').issues();
+const issues = await gh.repo('octocat', 'Hello-World').issues({ state: 'open', labels: 'bug' });
+
+// Get a single issue
+const issue = await gh.repo('octocat', 'Hello-World').issue(1);
+
+// Create an issue
+const newIssue = await gh.repo('octocat', 'Hello-World').createIssue({
+  title: 'Something is broken',
+  body:  'Steps to reproduce...',
+  labels: ['bug'],
+});
+```
+
+### Gists
+
+```typescript
+// List gists for the authenticated user
+const gists = await gh.listGists();
+const gists = await gh.listGists({ per_page: 50, since: '2024-01-01T00:00:00Z' });
+
+// Get a single gist (awaitable directly)
+const gist = await gh.gist('abc123');
+
+// Create a gist
+const newGist = await gh.createGist({
+  description: 'My snippet',
+  public: true,
+  files: {
+    'hello.ts': { content: 'console.log("hello")' },
+  },
+});
+
+// Update a gist
+const updated = await gh.gist('abc123').update({
+  description: 'Updated description',
+  files: {
+    'hello.ts': { content: 'console.log("updated")' },
+    'old.ts':   null, // deletes the file
+  },
+});
+
+// Delete a gist
+await gh.gist('abc123').delete();
+
+// Commits and forks
+const commits = await gh.gist('abc123').commits();
+const fork    = await gh.gist('abc123').fork();
+const forks   = await gh.gist('abc123').forks();
+
+// Star / unstar
+await gh.gist('abc123').star();
+await gh.gist('abc123').unstar();
+const starred = await gh.gist('abc123').isStarred(); // true | false
+
+// Comments
+const comments  = await gh.gist('abc123').comments();
+const comment   = await gh.gist('abc123').addComment({ body: 'Great snippet!' });
+const updated   = await gh.gist('abc123').updateComment(comment.id, { body: 'Even better!' });
+await gh.gist('abc123').deleteComment(comment.id);
+```
+
 ### Repository search
 
 ```typescript
@@ -266,7 +332,7 @@ The `event` object contains:
 | Field | Type | Description |
 |---|---|---|
 | `url` | `string` | Full URL that was requested |
-| `method` | `'GET'` | HTTP method used |
+| `method` | `'GET' \| 'POST' \| 'PATCH' \| 'DELETE' \| 'PUT'` | HTTP method used |
 | `startedAt` | `Date` | When the request started |
 | `finishedAt` | `Date` | When the request finished |
 | `durationMs` | `number` | Duration in milliseconds |
@@ -361,6 +427,11 @@ import type {
   // Webhooks & Content
   GitHubWebhook, WebhooksParams,
   GitHubContent, ContentParams,
+  // Issues
+  GitHubIssue, GitHubIssueComment, IssuesParams, CreateIssueData,
+  // Gists
+  GitHubGist, GistFile, GistCommit, GistFork, GistComment,
+  GistsParams, CreateGistData, UpdateGistData, GistCommentData,
 } from 'gh-api-client';
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,6 +104,28 @@
 
 ---
 
+## GistResource
+
+| Method | Endpoint | Status |
+|--------|----------|--------|
+| `listGists(params?)` | `GET /gists` | ✅ |
+| `gist(gistId).get()` | `GET /gists/{gist_id}` | ✅ |
+| `createGist(data)` | `POST /gists` | ✅ |
+| `gist(gistId).update(data)` | `PATCH /gists/{gist_id}` | ✅ |
+| `gist(gistId).delete()` | `DELETE /gists/{gist_id}` | ✅ |
+| `gist(gistId).commits(params?)` | `GET /gists/{gist_id}/commits` | ✅ |
+| `gist(gistId).fork()` | `POST /gists/{gist_id}/forks` | ✅ |
+| `gist(gistId).forks(params?)` | `GET /gists/{gist_id}/forks` | ✅ |
+| `gist(gistId).star()` | `PUT /gists/{gist_id}/star` | ✅ |
+| `gist(gistId).unstar()` | `DELETE /gists/{gist_id}/star` | ✅ |
+| `gist(gistId).isStarred()` | `GET /gists/{gist_id}/star` | ✅ |
+| `gist(gistId).comments(params?)` | `GET /gists/{gist_id}/comments` | ✅ |
+| `gist(gistId).addComment(data)` | `POST /gists/{gist_id}/comments` | ✅ |
+| `gist(gistId).updateComment(commentId, data)` | `PATCH /gists/{gist_id}/comments/{comment_id}` | ✅ |
+| `gist(gistId).deleteComment(commentId)` | `DELETE /gists/{gist_id}/comments/{comment_id}` | ✅ |
+
+---
+
 ## Cross-cutting concerns
 
 | Feature | Scope | Status |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "gh-api-client",
       "version": "1.4.0",
->>>>>>> origin/main
       "license": "MIT",
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",

--- a/src/GitHubClient.ts
+++ b/src/GitHubClient.ts
@@ -1,11 +1,13 @@
 import { Security } from './security/Security';
 import { GitHubApiError } from './errors/GitHubApiError';
 import { OrganizationResource } from './resources/OrganizationResource';
-import type { RequestFn, RequestListFn, RequestTextFn, RequestBodyFn, RequestPatchFn, RequestDeleteFn } from './resources/OrganizationResource';
+import type { RequestFn, RequestListFn, RequestTextFn, RequestBodyFn, RequestPatchFn, RequestDeleteFn, RequestPutFn } from './resources/OrganizationResource';
 import { RepositoryResource } from './resources/RepositoryResource';
 import { UserResource } from './resources/UserResource';
+import { GistResource } from './resources/GistResource';
 import type { GitHubUser } from './domain/User';
 import type { GitHubRepository, SearchReposParams } from './domain/Repository';
+import type { GitHubGist, GistsParams, CreateGistData } from './domain/Gist';
 import type { GitHubPagedResponse } from './domain/Pagination';
 
 /**
@@ -15,7 +17,7 @@ export interface RequestEvent {
   /** Full URL that was requested */
   url: string;
   /** HTTP method used */
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
   /** Timestamp when the request started */
   startedAt: Date;
   /** Timestamp when the request finished (success or error) */
@@ -312,6 +314,33 @@ export class GitHubClient {
       this.requestDelete(path, signal);
   }
 
+  private async requestPut(path: string, signal?: AbortSignal): Promise<void> {
+    const url = `${this.security.getApiUrl()}${path}`;
+    const startedAt = new Date();
+    let statusCode: number | undefined;
+    try {
+      const response = await fetch(url, {
+        method: 'PUT',
+        headers: this.security.getHeaders(),
+        signal,
+      });
+      statusCode = response.status;
+      if (!response.ok) {
+        throw new GitHubApiError(response.status, response.statusText);
+      }
+      this.emit('request', { url, method: 'PUT', startedAt, finishedAt: new Date(), durationMs: Date.now() - startedAt.getTime(), statusCode });
+    } catch (err) {
+      const finishedAt = new Date();
+      this.emit('request', { url, method: 'PUT', startedAt, finishedAt, durationMs: finishedAt.getTime() - startedAt.getTime(), statusCode, error: err instanceof Error ? err : new Error(String(err)) });
+      throw err;
+    }
+  }
+
+  private makeRequestPutFn(): RequestPutFn {
+    return (path: string, signal?: AbortSignal) =>
+      this.requestPut(path, signal);
+  }
+
   /**
    * Fetches the authenticated user's profile.
    *
@@ -455,6 +484,56 @@ export class GitHubClient {
       this.emit('request', { url, method: 'GET', startedAt, finishedAt, durationMs: finishedAt.getTime() - startedAt.getTime(), statusCode, error: err instanceof Error ? err : new Error(String(err)) });
       throw err;
     }
+  }
+
+  /**
+   * Returns a {@link GistResource} for a given gist ID.
+   *
+   * The returned resource can be awaited directly to fetch the gist,
+   * or chained to access nested resources (comments, forks, star).
+   *
+   * @param gistId - The gist ID
+   * @returns A chainable gist resource
+   *
+   * @example
+   * ```typescript
+   * const gist     = await gh.gist('abc123');
+   * const comments = await gh.gist('abc123').comments();
+   * await gh.gist('abc123').star();
+   * ```
+   */
+  gist(gistId: string): GistResource {
+    return new GistResource(
+      this.makeRequestFn(),
+      this.makeRequestListFn(),
+      this.makeRequestBodyFn(),
+      this.makeRequestPatchFn(),
+      this.makeRequestDeleteFn(),
+      this.makeRequestPutFn(),
+      gistId,
+    );
+  }
+
+  /**
+   * Lists gists for the authenticated user (or publicly if unauthenticated).
+   *
+   * `GET /gists`
+   *
+   * @param params - Optional filters: `since`, `per_page`, `page`
+   */
+  async listGists(params?: GistsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubGist>> {
+    return this.requestList<GitHubGist>('/gists', params as Record<string, string | number | boolean>, signal);
+  }
+
+  /**
+   * Creates a new gist.
+   *
+   * `POST /gists`
+   *
+   * @param data - Gist files and optional description/visibility
+   */
+  async createGist(data: CreateGistData, signal?: AbortSignal): Promise<GitHubGist> {
+    return this.requestPost<GitHubGist>('/gists', data, signal);
   }
 }
 

--- a/src/domain/Gist.ts
+++ b/src/domain/Gist.ts
@@ -1,0 +1,164 @@
+import type { GitHubUser } from './User';
+import type { PaginationParams } from './Pagination';
+
+/**
+ * Represents a single file within a GitHub Gist.
+ */
+export interface GistFile {
+  /** File name */
+  filename: string;
+  /** MIME type of the file */
+  type: string;
+  /** Programming language detected */
+  language: string | null;
+  /** URL to fetch the raw file content */
+  raw_url: string;
+  /** File size in bytes */
+  size: number;
+  /** File content (only present in single-gist responses) */
+  content?: string;
+  /** Whether the file content was truncated */
+  truncated?: boolean;
+}
+
+/**
+ * Represents a GitHub Gist.
+ */
+export interface GitHubGist {
+  /** Unique gist ID */
+  id: string;
+  /** Short description of the gist */
+  description: string | null;
+  /** Whether the gist is public */
+  public: boolean;
+  /** Owner of the gist */
+  owner: GitHubUser | null;
+  /** User who forked this gist, if applicable */
+  user: GitHubUser | null;
+  /** Map of filename to file metadata */
+  files: Record<string, GistFile>;
+  /** Number of comments */
+  comments: number;
+  /** URL to the gist's comments API */
+  comments_url: string;
+  /** GitHub web URL for the gist */
+  html_url: string;
+  /** Git pull URL */
+  git_pull_url: string;
+  /** Git push URL */
+  git_push_url: string;
+  /** ISO 8601 creation timestamp */
+  created_at: string;
+  /** ISO 8601 last-update timestamp */
+  updated_at: string;
+  /** Node ID */
+  node_id: string;
+  /** Whether the authenticated user has starred this gist */
+  starred?: boolean;
+  /** Fork metadata, if this is a fork */
+  fork_of?: GitHubGist | null;
+  /** Number of forks */
+  forks_url?: string;
+  /** Number of commits */
+  commits_url?: string;
+}
+
+/**
+ * Represents a single commit in a gist's history.
+ */
+export interface GistCommit {
+  /** The commit URL */
+  url: string;
+  /** The commit version (SHA) */
+  version: string;
+  /** The user who made this commit */
+  user: GitHubUser | null;
+  /** Change status for this commit */
+  change_status: {
+    total: number;
+    additions: number;
+    deletions: number;
+  };
+  /** ISO 8601 committed timestamp */
+  committed_at: string;
+}
+
+/**
+ * Represents a fork of a gist.
+ */
+export interface GistFork {
+  /** Unique gist ID of the fork */
+  id: string;
+  /** Owner of the fork */
+  user: GitHubUser;
+  /** GitHub web URL of the fork */
+  html_url: string;
+  /** ISO 8601 creation timestamp */
+  created_at: string;
+  /** ISO 8601 last-update timestamp */
+  updated_at: string;
+}
+
+/**
+ * Represents a comment on a gist.
+ */
+export interface GistComment {
+  /** Unique comment ID */
+  id: number;
+  /** The comment body */
+  body: string;
+  /** Author of the comment */
+  user: GitHubUser | null;
+  /** ISO 8601 creation timestamp */
+  created_at: string;
+  /** ISO 8601 last-update timestamp */
+  updated_at: string;
+}
+
+/**
+ * Query parameters for listing gists.
+ */
+export interface GistsParams extends PaginationParams {
+  /** Only gists updated after this ISO 8601 timestamp */
+  since?: string;
+}
+
+/**
+ * File entry for creating or updating a gist.
+ */
+export interface GistFileInput {
+  /** File content */
+  content: string;
+  /** New filename (used when renaming during update) */
+  filename?: string;
+}
+
+/**
+ * Body for creating a new gist.
+ */
+export interface CreateGistData {
+  /** Map of filename to file input */
+  files: Record<string, GistFileInput>;
+  /** Short description */
+  description?: string;
+  /** Whether the gist should be public */
+  public?: boolean;
+}
+
+/**
+ * Body for updating an existing gist.
+ */
+export interface UpdateGistData {
+  /** Map of filename to file input. Set content to empty string to delete a file. */
+  files?: Record<string, GistFileInput | null>;
+  /** Updated description */
+  description?: string;
+}
+
+/**
+ * Body for creating or updating a gist comment.
+ */
+export interface GistCommentData {
+  /** The comment body */
+  body: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { PullRequestResource } from './resources/PullRequestResource';
 export { CommitResource } from './resources/CommitResource';
 export { UserResource } from './resources/UserResource';
 export { IssueResource } from './resources/IssueResource';
+export { GistResource } from './resources/GistResource';
 export type { GitHubUser, UsersParams, SearchUsersParams } from './domain/User';
 export type { GitHubOrganization, OrgMembersParams, CreateOrgRepoData } from './domain/Organization';
 export type { GitHubRepository, ReposParams, ForksParams, SearchReposParams, CreateForkData } from './domain/Repository';
@@ -22,4 +23,5 @@ export type { GitHubRelease, GitHubReleaseAsset, ReleasesParams } from './domain
 export type { GitHubWebhook, WebhooksParams, CreateWebhookData, UpdateWebhookData } from './domain/Webhook';
 export type { GitHubContent, ContentParams } from './domain/Content';
 export type { GitHubIssue, GitHubIssueComment, IssuesParams, CreateIssueData } from './domain/Issue';
+export type { GitHubGist, GistFile, GistCommit, GistFork, GistComment, GistsParams, CreateGistData, UpdateGistData, GistCommentData } from './domain/Gist';
 export type { PaginationParams, GitHubPagedResponse } from './domain/Pagination';

--- a/src/resources/GistResource.ts
+++ b/src/resources/GistResource.ts
@@ -1,0 +1,181 @@
+import type { GitHubGist, GistCommit, GistFork, GistComment, GistsParams, CreateGistData, UpdateGistData, GistCommentData } from '../domain/Gist';
+import type { GitHubPagedResponse } from '../domain/Pagination';
+import type { RequestFn, RequestListFn, RequestBodyFn, RequestPatchFn, RequestDeleteFn, RequestPutFn } from './OrganizationResource';
+
+/**
+ * Provides access to GitHub Gist endpoints.
+ *
+ * Obtained via `GitHubClient.gist(gistId)` for single-gist operations,
+ * or use the static list methods directly on the client.
+ *
+ * @example
+ * ```typescript
+ * const gist = await gh.gist('abc123');
+ * const comments = await gh.gist('abc123').comments();
+ * await gh.gist('abc123').star();
+ * ```
+ */
+export class GistResource implements PromiseLike<GitHubGist> {
+  private readonly basePath: string;
+
+  /** @internal */
+  constructor(
+    private readonly request: RequestFn,
+    private readonly requestList: RequestListFn,
+    private readonly requestBody: RequestBodyFn,
+    private readonly requestPatch: RequestPatchFn,
+    private readonly requestDelete: RequestDeleteFn,
+    private readonly requestPut: RequestPutFn,
+    gistId: string,
+  ) {
+    this.basePath = `/gists/${gistId}`;
+  }
+
+  /**
+   * Allows the resource to be awaited directly, resolving with the gist.
+   * Delegates to {@link GistResource.get}.
+   */
+  then<TResult1 = GitHubGist, TResult2 = never>(
+    onfulfilled?: ((value: GitHubGist) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.get().then(onfulfilled, onrejected);
+  }
+
+  /**
+   * Fetches a single gist.
+   *
+   * `GET /gists/{gist_id}`
+   */
+  async get(signal?: AbortSignal): Promise<GitHubGist> {
+    return this.request<GitHubGist>(this.basePath, undefined, signal);
+  }
+
+  /**
+   * Updates an existing gist.
+   *
+   * `PATCH /gists/{gist_id}`
+   */
+  async update(data: UpdateGistData, signal?: AbortSignal): Promise<GitHubGist> {
+    return this.requestPatch<GitHubGist>(this.basePath, data, signal);
+  }
+
+  /**
+   * Deletes a gist.
+   *
+   * `DELETE /gists/{gist_id}`
+   */
+  async delete(signal?: AbortSignal): Promise<void> {
+    return this.requestDelete(this.basePath, signal);
+  }
+
+  /**
+   * Lists commits for a gist.
+   *
+   * `GET /gists/{gist_id}/commits`
+   */
+  async commits(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GistCommit>> {
+    return this.requestList<GistCommit>(
+      `${this.basePath}/commits`,
+      params as Record<string, string | number | boolean>,
+      signal,
+    );
+  }
+
+  /**
+   * Forks a gist.
+   *
+   * `POST /gists/{gist_id}/forks`
+   */
+  async fork(signal?: AbortSignal): Promise<GitHubGist> {
+    return this.requestBody<GitHubGist>(`${this.basePath}/forks`, {}, signal);
+  }
+
+  /**
+   * Lists forks of a gist.
+   *
+   * `GET /gists/{gist_id}/forks`
+   */
+  async forks(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GistFork>> {
+    return this.requestList<GistFork>(
+      `${this.basePath}/forks`,
+      params as Record<string, string | number | boolean>,
+      signal,
+    );
+  }
+
+  /**
+   * Stars a gist for the authenticated user.
+   *
+   * `PUT /gists/{gist_id}/star`
+   */
+  async star(signal?: AbortSignal): Promise<void> {
+    return this.requestPut(`${this.basePath}/star`, signal);
+  }
+
+  /**
+   * Unstars a gist for the authenticated user.
+   *
+   * `DELETE /gists/{gist_id}/star`
+   */
+  async unstar(signal?: AbortSignal): Promise<void> {
+    return this.requestDelete(`${this.basePath}/star`, signal);
+  }
+
+  /**
+   * Checks whether the authenticated user has starred a gist.
+   * Returns `true` if starred (HTTP 204), `false` if not (HTTP 404).
+   *
+   * `GET /gists/{gist_id}/star`
+   */
+  async isStarred(signal?: AbortSignal): Promise<boolean> {
+    try {
+      await this.request<void>(`${this.basePath}/star`, undefined, signal);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Lists comments on a gist.
+   *
+   * `GET /gists/{gist_id}/comments`
+   */
+  async comments(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GistComment>> {
+    return this.requestList<GistComment>(
+      `${this.basePath}/comments`,
+      params as Record<string, string | number | boolean>,
+      signal,
+    );
+  }
+
+  /**
+   * Creates a comment on a gist.
+   *
+   * `POST /gists/{gist_id}/comments`
+   */
+  async addComment(data: GistCommentData, signal?: AbortSignal): Promise<GistComment> {
+    return this.requestBody<GistComment>(`${this.basePath}/comments`, data, signal);
+  }
+
+  /**
+   * Updates a comment on a gist.
+   *
+   * `PATCH /gists/{gist_id}/comments/{comment_id}`
+   */
+  async updateComment(commentId: number, data: GistCommentData, signal?: AbortSignal): Promise<GistComment> {
+    return this.requestPatch<GistComment>(`${this.basePath}/comments/${commentId}`, data, signal);
+  }
+
+  /**
+   * Deletes a comment on a gist.
+   *
+   * `DELETE /gists/{gist_id}/comments/{comment_id}`
+   */
+  async deleteComment(commentId: number, signal?: AbortSignal): Promise<void> {
+    return this.requestDelete(`${this.basePath}/comments/${commentId}`, signal);
+  }
+}
+
+export type { GistsParams, CreateGistData, UpdateGistData, GistCommentData };

--- a/src/resources/OrganizationResource.ts
+++ b/src/resources/OrganizationResource.ts
@@ -42,6 +42,9 @@ export type RequestPatchFn = <T>(
 /** @internal */
 export type RequestDeleteFn = (path: string, signal?: AbortSignal) => Promise<void>;
 
+/** @internal */
+export type RequestPutFn = (path: string, signal?: AbortSignal) => Promise<void>;
+
 /**
  * Represents a GitHub organization resource with chainable async methods.
  *


### PR DESCRIPTION
## What does this PR do?

Add module for github gist

## Related issue

closes #7

## Checklist

- [x] `npm test` passes
- [x] New code has tests
- [x] `src/index.ts` exports any new public types
- [x] README updated if a new endpoint was added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
