### PR TITLE
feat: add publicEvents to UserResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ const content = await gh.user('octocat').repo('Hello-World').raw('README.md');
 // Followers and following
 const followers = await gh.user('octocat').followers();
 const following = await gh.user('octocat').following();
+
+// List public events performed by a user
+const events = await gh.user('octocat').publicEvents();
+const events = await gh.user('octocat').publicEvents({ per_page: 30 });
 ```
 
 ### Organizations
@@ -427,6 +431,8 @@ import type {
   // Webhooks & Content
   GitHubWebhook, WebhooksParams,
   GitHubContent, ContentParams,
+  // Events
+  GitHubEvent, GitHubActor, EventsParams,
   // Issues
   GitHubIssue, GitHubIssueComment, IssuesParams, CreateIssueData,
   // Gists

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,7 @@
 | `repo(name)` | — chainable | ✅ |
 | `followers(params?)` | `GET /users/{username}/followers` | ✅ |
 | `following(params?)` | `GET /users/{username}/following` | ✅ |
+| `publicEvents(params?)` | `GET /users/{username}/events/public` | ✅ |
 
 ---
 

--- a/src/domain/Event.ts
+++ b/src/domain/Event.ts
@@ -1,0 +1,54 @@
+import type { GitHubUser } from './User';
+import type { GitHubRepository } from './Repository';
+
+/**
+ * Represents a GitHub public event as returned by the Activity API.
+ *
+ * @see {@link https://docs.github.com/en/rest/activity/events}
+ */
+export interface GitHubEvent {
+  /** Unique event ID */
+  id: string;
+  /** The type of event (e.g., `'PushEvent'`, `'PullRequestEvent'`) */
+  type: string;
+  /** The actor who triggered the event */
+  actor: GitHubActor;
+  /** The repository where the event occurred */
+  repo: Pick<GitHubRepository, 'id' | 'name'> & { url: string };
+  /** Event-specific payload — shape varies by event type */
+  payload: Record<string, unknown>;
+  /** Whether the event is public */
+  public: boolean;
+  /** ISO 8601 timestamp of when the event occurred */
+  created_at: string;
+  /** Organization context, present only for org events */
+  org?: GitHubActor;
+}
+
+/**
+ * Minimal actor object embedded in GitHub events.
+ */
+export interface GitHubActor {
+  /** Unique numeric ID */
+  id: number;
+  /** Login name */
+  login: string;
+  /** Display name */
+  display_login?: string;
+  /** URL to the actor's avatar */
+  avatar_url: string;
+  /** API URL for the actor */
+  url: string;
+  /** Gravatar ID */
+  gravatar_id: string;
+}
+
+/**
+ * Query parameters for event listing endpoints.
+ */
+export interface EventsParams {
+  /** Results per page (max 100) */
+  per_page?: number;
+  /** Page number */
+  page?: number;
+}

--- a/src/resources/UserResource.ts
+++ b/src/resources/UserResource.ts
@@ -1,5 +1,6 @@
 import type { GitHubUser } from '../domain/User';
 import type { GitHubRepository, ReposParams } from '../domain/Repository';
+import type { GitHubEvent, EventsParams } from '../domain/Event';
 import type { GitHubPagedResponse } from '../domain/Pagination';
 import type { RequestFn, RequestListFn, RequestTextFn, RequestBodyFn, RequestPatchFn, RequestDeleteFn } from './OrganizationResource';
 import { RepositoryResource } from './RepositoryResource';
@@ -127,6 +128,22 @@ export class UserResource implements PromiseLike<GitHubUser> {
   async followers(params?: { per_page?: number; page?: number }, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubUser>> {
     return this.requestList<GitHubUser>(
       `${this.basePath}/followers`,
+      params as Record<string, string | number | boolean>,
+      signal,
+    );
+  }
+
+  /**
+   * Lists public events performed by this user.
+   *
+   * `GET /users/{username}/events/public`
+   *
+   * @param params - Optional pagination: `per_page`, `page`
+   * @returns A paged response of public events
+   */
+  async publicEvents(params?: EventsParams, signal?: AbortSignal): Promise<GitHubPagedResponse<GitHubEvent>> {
+    return this.requestList<GitHubEvent>(
+      `${this.basePath}/events/public`,
       params as Record<string, string | number | boolean>,
       signal,
     );

--- a/test-client/test.js
+++ b/test-client/test.js
@@ -46,6 +46,13 @@ async function test() {
       // Get a commit (https://docs.github.com/rest/commits/commits#get-a-commit)
       const commit = await gh.repo(owner, repository).commit('HEAD').get();
       console.log('commit message: ', commit.commit.message);
+
+      // List public events for a user (https://docs.github.com/rest/activity/events#list-public-events-for-a-user)
+      const events = await gh.user(owner).publicEvents({ per_page: 5 });
+      events.values.forEach(({ type, created_at }) => {
+        console.log('event type: ', type, '| date: ', created_at);
+      });
+      console.log('total events fetched: ', events.values.length);
 }
 
 test().catch(console.error);

--- a/tests/GitHubClient.test.ts
+++ b/tests/GitHubClient.test.ts
@@ -13,6 +13,7 @@ import type { GitHubReview, GitHubReviewComment } from '../src/domain/Review';
 import type { GitHubPullRequestFile } from '../src/domain/PullRequestFile';
 import type { GitHubCommitStatus, GitHubCombinedStatus } from '../src/domain/CommitStatus';
 import type { GitHubIssue } from '../src/domain/Issue';
+import type { GitHubEvent } from '../src/domain/Event';
 
 const API_URL = 'https://api.github.com';
 const TOKEN = 'ghp_myToken';
@@ -443,6 +444,51 @@ describe('GitHubClient.user(login)', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       `${API_URL}/users/octocat/following`,
+      expect.anything(),
+    );
+  });
+
+  it('fetches public events for a user', async () => {
+    const gh = new GitHubClient({ token: TOKEN });
+    const mockEvent: GitHubEvent = {
+      id: '123456789',
+      type: 'PushEvent',
+      actor: {
+        id: 1,
+        login: 'octocat',
+        avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+        url: 'https://api.github.com/users/octocat',
+        gravatar_id: '',
+      },
+      repo: {
+        id: 1296269,
+        name: 'octocat/Hello-World',
+        url: 'https://api.github.com/repos/octocat/Hello-World',
+      },
+      payload: { push_id: 1, size: 1, distinct_size: 1, ref: 'refs/heads/main' },
+      public: true,
+      created_at: '2011-09-06T17:26:27Z',
+    };
+    mockJsonResponse(pagedOf(mockEvent));
+
+    const result = await gh.user('octocat').publicEvents();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API_URL}/users/octocat/events/public`,
+      expect.anything(),
+    );
+    expect(result.values[0].type).toBe('PushEvent');
+    expect(result.values[0].public).toBe(true);
+  });
+
+  it('forwards per_page and page params to publicEvents', async () => {
+    const gh = new GitHubClient({ token: TOKEN });
+    mockJsonResponse([]);
+
+    await gh.user('octocat').publicEvents({ per_page: 10, page: 2 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API_URL}/users/octocat/events/public?per_page=10&page=2`,
       expect.anything(),
     );
   });


### PR DESCRIPTION
## What does this PR do?

Implement GET /users/{username}/events/public via a new publicEvents() method on UserResource, backed by a new GitHubEvent domain type.

## Related issue

Closes #12

## Checklist

- [x] `npm test` passes
- [x] New code has tests
- [x] `src/index.ts` exports any new public types
- [x] README updated if a new endpoint was added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
